### PR TITLE
Add OSI license requriements

### DIFF
--- a/_plays/08.md
+++ b/_plays/08.md
@@ -3,13 +3,13 @@ id: 8
 title: Choose a modern technology stack
 ---
 
-The technology decisions we make need to enable development teams to work efficiently and enable services to scale easily and cost-effectively. Our choices for hosting infrastructure, databases, software frameworks, programming languages and the rest of the technology stack should seek to avoid vendor lock-in and match what successful modern consumer and enterprise software companies would choose today. In particular, digital services teams should consider using open source, cloud-based, and commodity solutions across the technology stack, because of their widespread adoption and support by successful consumer and enterprise technology companies in the private sector.
+The technology decisions we make need to enable development teams to work efficiently and enable services to scale easily and cost-effectively. Our choices for hosting infrastructure, databases, software frameworks, programming languages and the rest of the technology stack should seek to avoid vendor lock-in and match what successful modern consumer and enterprise software companies would choose today. In particular, digital services teams should consider using software open source software distributed with an [OSI Approved Open Source License](http://opensource.org/licenses), cloud-based, and commodity solutions across the technology stack, because of their widespread adoption and support by successful consumer and enterprise technology companies in the private sector.
 
 #### checklist
 1. Choose software frameworks that are commonly used by private-sector companies creating similar services
 2. Whenever possible, ensure that software can be deployed on a variety of commodity hardware types
 3. Ensure that each project has clear, understandable instructions for setting up a local development environment, and that team members can be quickly added or removed from projects
-4. [Consider open source software solutions](http://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/memotociostechnologyneutrality.pdf) at every layer of the stack
+4. [Consider open source software solutions](http://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/memotociostechnologyneutrality.pdf) distributed with an [OSI Approved Open Source License](http://opensource.org/licenses) at every layer of the stack
 
 #### key questions
 - What is your development stack and why did you choose it?


### PR DESCRIPTION
The plays should explicitly require that software carry an Open Source Initiative (OSI) Approved Open Source License to ensure software freedom, meet the expectations of those involved with the open source community and ensure the benefits open source software and licenses afford. There are many organizations which use the label "open source" but develop their own licenses (or may not carry any license) and thus do not comply with the OSD resulting in limitations in software freedom as guaranteed by the OSI and OSD.

Open source licenses are only licenses that comply with the Open Source Definition — in brief, they allow software to be freely used, modified, and shared. To be approved by the OSI, a license must go through the Open Source Initiative's license review process and as such is the industry and globally recognized standard for identifying open source software.