### PR TITLE
Add OSI license requriements

### DIFF
--- a/_plays/13.md
+++ b/_plays/13.md
@@ -19,6 +19,6 @@ When we collaborate in the open and publish our data publicly, we can improve Go
 #### key questions
 - How are you collecting user feedback for bugs and issues?
 - If there is an API, what capabilities does it provide? Who uses it? How is it documented?
-- If the codebase has not been released under an open source license, explain why.
-- What components are made available to the public as open source?
+- If the codebase has not been released under an [OSI Approved Open Source License](http://opensource.org/licenses), explain why.
+- What components are made available to the public through an [OSI Approved Open Source License](http://opensource.org/licenses)?
 - What datasets are made available to the public?


### PR DESCRIPTION

The plays should explicitly require that software carry an Open Source Initiative (OSI) Approved Open Source License to ensure software freedom, meet the expectations of those involved with the open source community and ensure the benefits open source software and licenses afford. There are many organizations which use the label "open source" but develop their own licenses (or may not carry any license) and thus do not comply with the OSD resulting in limitations in software freedom as guaranteed by the OSI and OSD.

Open source licenses are only licenses that comply with the Open Source Definition — in brief, they allow software to be freely used, modified, and shared. To be approved by the OSI, a license must go through the Open Source Initiative's license review process and as such is the industry and globally recognized standard for identifying open source software.