### PR TITLE
added relevant playbooks 

### DIFF
--- a/_plays/01.md
+++ b/_plays/01.md
@@ -3,7 +3,7 @@ id: 1
 title: Understand what people need
 ---
 
-We must begin digital projects by exploring and pinpointing the needs of the people who will use the service, and the ways the service will fit into their lives. Whether the users are members of the public or government employees, policy makers must include real people in their design process from the beginning. The needs of people — not constraints of government structures or silos — should inform technical and design decisions. We need to continually test the products we build with real people to keep us honest about what is important.
+We must begin digital projects by exploring and pinpointing the needs of the people who will use the service, and the ways the service will fit into their lives. Whether the users are members of the public or government employees, policy makers must include real people in their design process from the beginning. The needs of people — not constraints of government structures or silos — should inform technical and design decisions. We need to continually test the products we build with real people to keep us honest about what is important. _For additional resources and case study examples see: [U.S. Public Participation Playbook](https://participation.usa.gov/)._ 
 
 #### checklist
 1. Early in the project, spend time with current and prospective users of the service

--- a/_plays/13.md
+++ b/_plays/13.md
@@ -9,7 +9,7 @@ When we collaborate in the open and publish our data publicly, we can improve Go
 1. Offer users a mechanism to report bugs and issues, and be responsive to these reports
 2. Provide datasets to the public, in their entirety, through bulk downloads and APIs (application programming interfaces)
 3. Ensure that data from the service is explicitly in the public domain, and that rights are waived globally via an international public domain dedication, such as the “Creative Commons Zero” waiver
-4. Catalog data in the agency’s enterprise data inventory and add any public datasets to the agency’s public data listing
+4. Catalog data in the agency’s enterprise data inventory and add any public datasets to the agency’s public data listing in accordance with [Project Open Data](http://project-open-data.github.io/)
 5. Ensure that we maintain the rights to all data developed by third parties in a manner that is releasable and reusable at no cost to the public
 6. Ensure that we maintain contractual rights to all custom software developed by third parties in a manner that is publishable and reusable at no cost
 7. When appropriate, create an API for third parties and internal users to interact with the service directly


### PR DESCRIPTION
* The Default by Open play references Enterprise Data Inventory and Public Data Listing, but these terms could be meaningless to folks not familiar with Project Open Data. 

* Similarly, the Public Participation Playbook, which came out after this Playbook, has a lot of relevant resources and case study examples of how to include users from day 1. 

@jlberryhill  