### PR TITLE
Update titles and links to reflect USDS naming conventions

### DIFF
--- a/_includes/introduction.md
+++ b/_includes/introduction.md
@@ -1,4 +1,4 @@
-# U.S. Digital Services Playbook
+# Digital Services Playbook
 
 The American people expect to interact with government through digital channels such as websites, email, and mobile applications. By building digital services that meet their needs, we can make the delivery of our policy and programs more effective.   
 

--- a/_layouts/techfar.html
+++ b/_layouts/techfar.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>The TechFAR</title>
+  <title>The TechFAR Handbook — from the U.S. Digital Service</title>
   <meta charset='UTF-8'/>
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
   <link rel='shortcut icon' href='{{site.baseurl}}/assets/images/favicon.ico' type='image/x-icon' />

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>The U.S. Digital Services Playbook</title>
+  <title>The Digital Services Playbook — from the U.S. Digital Service</title>
   <meta charset='UTF-8'/>
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
   <link href='//fonts.googleapis.com/css?family=Merriweather:400,300,700|Source+Sans+Pro:400,700' rel='stylesheet' type='text/css'>
@@ -19,7 +19,7 @@
    <div class="outer_container">
     <div class="inner_container">
 
-      <a href="#introduction"><h3>U.S. Digital Services Playbook</h3></a>
+      <a href="#introduction"><h3>Digital Services Playbook</h3></a>
       <ul class="nav">
         {% for play in site.plays %}
           <li class="play_square"><a href="#play{{ play.id }}" title="View Play {{ play.id }}: {{ play.title }}">{{ play.id }}</a></li>
@@ -35,7 +35,7 @@
 <div id="introduction">
   <div class="outer_container">
     <div class="inner_container">
-      <a id="usds_logo" href="http://whitehouse.gov/digital/united-states-digital-service" title="Link to the United States Digital Service"><img src='{{site.baseurl}}/assets/images/USDS-logo-rays-transparent.png' alt="Logo of the United States Digital Service"></a>
+      <a id="usds_logo" href="https://www.usds.gov" title="Link to the United States Digital Service"><img src='{{site.baseurl}}/assets/images/USDS-logo-rays-transparent.png' alt="Logo of the United States Digital Service"></a>
       {% capture introduction %}{% include introduction.md %}{% endcapture %}
       {{ introduction | markdownify }}
       <div class="button">


### PR DESCRIPTION
This makes the title of the playbook (the "Digital Services Playbook") consistent throughout the document. The change is to make it clear that while the U.S. Digital Service created the Playbook and follows it on our projects, we believe these plays can apply to all government digital services, not only those that our team is currently working on.

This PR also updates the link to the U.S. Digital Service homepage with our new URL: https://www.usds.gov