### PR TITLE
Remove date stamp for last update

### DIFF
--- a/404.md
+++ b/404.md
@@ -6,5 +6,3 @@ layout: "404"
 # Page Not Found
 
 [Return to CIO.gov](https://cio.gov)
-
-Last Update August 8, 10:48am


### PR DESCRIPTION
The timestamp is outdated since the last change to the file was well passed the current date. Additionally, it's just too tedious to maintain a timestamp on an individual page. 