### PR TITLE
Update config and ignore files to prevent build issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ _site/*
 .DS_Store
 notes/*
 .sass-cache/*
-.bundle
+.bundle/
+vendor/

--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,6 @@ markdown: kramdown
 
 sass:
     sass_dir: assets/_sass
+
+exclude:
+    - vendor/bundle


### PR DESCRIPTION
As noted in https://github.com/jekyll/jekyll/issues/5267, There can become a build issue if the user opts to have the bundle gem install the dependencies into an alternative path. Since the common alternative is the vendor directory I've included related updates to address it.