### PR TITLE
Default to open: APIs should be versioned

### DIFF
--- a/_plays/13.md
+++ b/_plays/13.md
@@ -12,13 +12,13 @@ When we collaborate in the open and publish our data publicly, we can improve Go
 4. Catalog data in the agency’s enterprise data inventory and add any public datasets to the agency’s public data listing
 5. Ensure that we maintain the rights to all data developed by third parties in a manner that is releasable and reusable at no cost to the public
 6. Ensure that we maintain contractual rights to all custom software developed by third parties in a manner that is publishable and reusable at no cost
-7. When appropriate, create an API for third parties and internal users to interact with the service directly
+7. When appropriate, create a versioned API for third parties and internal users to interact with the service directly
 8. When appropriate, publish source code of projects or components online
 9. When appropriate, share your development process and progress publicly
 
 ### Key Questions
 - How are you collecting user feedback for bugs and issues?
-- If there is an API, what capabilities does it provide? Who uses it? How is it documented?
+- If there is an API, what capabilities does it provide? Is it versioned? Who uses it? How is it documented?
 - If the codebase has not been released under an open source license, explain why.
 - What components are made available to the public as open source?
 - What datasets are made available to the public?


### PR DESCRIPTION
A tweak to the general recommendation to create APIs.  APIs, especially new ones, should always be versioned.  Versioning just entails encapsulating the API in a namespace like "/api/v1/".  The reason for doing this is that if you need to ship a later version that has backward-incompatible features (maybe you tweak the data model or semantics), this structure makes it easy to do so without breaking the ecosystem that was built around the earlier release.

Inspired by this observation: https://twitter.com/longhotsummer/status/1126473395355435008