### PR TITLE
Play 3: Update USWDS name

### DIFF
--- a/_plays/03.md
+++ b/_plays/03.md
@@ -6,7 +6,7 @@ title: Make it simple and intuitive
 Using a government service shouldn’t be stressful, confusing, or daunting. It’s our job to build services that are simple and intuitive enough that users succeed the first time, unaided.
 
 ### Checklist
-1. Use a simple and flexible design style guide for the service. Use the [U.S. Web Design Standards](https://playbook.cio.gov/designstandards) as a default 
+1. Use a simple and flexible design style guide for the service. Use the [U.S. Web Design System](https://playbook.cio.gov/designstandards) as a default 
 2. Use the design style guide consistently for related digital services
 3. Give users clear information about where they are in each step of the process
 4. Follow accessibility best practices to ensure all people can use the service


### PR DESCRIPTION
The U.S. Web Design Standards are now referred to as the U.S. Web Design System.

This pull request addresses proposed solution 2 in issue #232; however, it doesn't address solution 1 in issue #232, in which the redirect from https://playbook.cio.gov/designstandards needs to be updated as well.